### PR TITLE
Fix show-plugin btest for the transition to Bro 2.7

### DIFF
--- a/tests/Baseline/postgres.show-plugin/output
+++ b/tests/Baseline/postgres.show-plugin/output
@@ -1,4 +1,4 @@
-Johanna::PostgreSQL - PostgreSQL log writer and input reader (dynamic, version 0.2)
+Johanna::PostgreSQL - PostgreSQL log writer and input reader (dynamic, version)
     [Writer] PostgreSQL (Log::WRITER_POSTGRESQL)
     [Reader] PostgreSQL (Input::READER_POSTGRESQL)
     [Constant] LogPostgres::default_hostname

--- a/tests/postgres/show-plugin.bro
+++ b/tests/postgres/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN Johanna::PostgreSQL >output
+# @TEST-EXEC: bro -NN Johanna::PostgreSQL |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.
